### PR TITLE
Add Windows 7 build support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2.2.0", features = [] }
+tauri-winres = "0.3"
 
 [dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ cargo tauri build
 
 File cài đặt cho Windows sẽ được tạo trong `target/release/bundle`.
 
+### Tương thích Windows 7
+
+Ứng dụng kèm manifest hỗ trợ Windows 7. Khi đóng gói trên hệ điều hành khác,
+hãy chỉ định toolchain Windows:
+
+```bash
+cargo tauri build --target x86_64-pc-windows-msvc
+```
+
+Để hạn chế phần mềm diệt virus nhận nhầm, hãy ký số file thực thi sau khi đóng
+gói.
+
 ## Cấu trúc thư mục
 
 - `src/` - mã nguồn Rust khởi chạy ứng dụng và chạy các tiến trình nền

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,9 @@
 fn main() {
-  tauri_build::build()
+  tauri_build::build();
+  #[cfg(target_os = "windows")]
+  {
+    let mut res = tauri_winres::WindowsResource::new();
+    res.set_manifest_file("windows/win7.manifest");
+    res.compile().expect("failed to compile windows resources");
+  }
 }

--- a/windows/win7.manifest
+++ b/windows/win7.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
## Summary
- add Windows 7 manifest and compile it on build
- document Windows 7 build steps and note about code signing

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_b_686dd0e0400c8326bcafb5d99a52f820